### PR TITLE
Send space to clear channel name.

### DIFF
--- a/bc125py/sdo.py
+++ b/bc125py/sdo.py
@@ -740,7 +740,7 @@ class Channel(_ScannerDataObject):
 
 	def to_write_command(self) -> tuple:
 		return self.to_fetch_command() + (
-			self.name,
+			self.name if self.name else " ",
 			freq_to_scanner(self.frequency),
 			self.modulation.value,
 			self.ctcss,


### PR DESCRIPTION
For the "Set Channel Info" command, sending an empty channel name (where there's nothing between the commas in the command) leaves the channel name unchanged. To clear a channel name, you can send a single space (confirmed on BC125AT, firmware 1.04.02).